### PR TITLE
[BUGFIX] Pass object type check result to partials that use it

### DIFF
--- a/Resources/Private/Templates/Vimeo.html
+++ b/Resources/Private/Templates/Vimeo.html
@@ -3,6 +3,6 @@
 	data-namespace-typo3-fluid="true"
 >
 
-<f:render partial="Iframe" arguments="{file: file, src: src, attributes: attributes, paddingTop: paddingTop, type: type}" />
+<f:render partial="Iframe" arguments="{file: file, src: src, attributes: attributes, paddingTop: paddingTop, type: type, isReference: isReference}" />
 
 </html>

--- a/Resources/Private/Templates/YouTube.html
+++ b/Resources/Private/Templates/YouTube.html
@@ -3,6 +3,6 @@
 	data-namespace-typo3-fluid="true"
 >
 
-<f:render partial="Iframe" arguments="{file: file, src: src, attributes: attributes, paddingTop: paddingTop, type: type}" />
+<f:render partial="Iframe" arguments="{file: file, src: src, attributes: attributes, paddingTop: paddingTop, type: type, isReference: isReference}" />
 
 </html>


### PR DESCRIPTION
This resolves issue #5 by passing the result of the check that was introduced with #2 for issue #1 to the partial files that use it.
Previously the value was always `null` resulting in errors or wrong behaviour if a FileReference object was passed.